### PR TITLE
gpt suggestion

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -2,78 +2,106 @@
 title:  Re-Search made simple
 ---
 
-<div class="center" markdown> <p>With CDA you search by harmonized, common language terms. Using simple language you can get information about the subjects, files, or specimens that you care about in a standard dataframe format (tsv) that you can open in Excel, integrate into a pipeline or upload to your favorite cloud resource.</p></div>
+# Search cancer data across multiple NCI data commons—instantly
 
+Cancer data is distributed across multiple systems—CDA brings it together.
 
-<div class="grid cards" markdown>
+Find subjects, files, and studies using harmonized terms across repositories. No coding required.
 
--   :material-clock-fast:{ .lg .middle } __Don't code? No problem!__
+```{admonition} 
+:class: important
 
-    ---
-
-    Browse through a curated dataset of all subjects that have data at multiple data centers using an intuitive filtering tool right in this website. 
-<a href="../interactive/" title="interactive search" class="md-button md-button">Head to our interactive page to try it out.
-</a></p>
-
--   :material-clock-fast:{ .lg .middle } __Low code, no install__
-
-    ---
-
-    Fill in the blanks in our pre-built queries to find the data you need without installing a thing. <p>Send your results to [Broad Institute FireCloud:octicons-link-external-16:](https://datacommons.cancer.gov/analytical-resource/broad-institute-firecloud){:target="_blank"} or [Velsera Cancer Genomics Cloud:octicons-link-external-16:](https://www.cancergenomicscloud.org/){:target="_blank"} for a complete cloud experience. Find the data you need, fetch all the files, and run your favorite bioinformatics pipeline *all without ever leaving your web browser.*<p>
-<a href="https://colab.research.google.com/github/CancerDataAggregator/Community-Notebooks/blob/main/Tutorials/Welcome.ipynb" title="Try it now" class="md-button md-button">Launch CDA in the cloud
-</a></p>
-
--   :fontawesome-brands-python:{ .lg .middle } __Power users__
-
-    ---
-
-    Install `cdapython` with `pip` and get up
-    and running in no time
-
-    ```bash
-    pip3 uninstall -y cdapython; pip3 install git+https://github.com/CancerDataAggregator/cdapython.git@develop
-    python3
-    ```
-
-    ```python
-    from cdapython import *
-    ```
-
--   :fontawesome-brands-python:{ .lg .middle } __Code in the Cloud__
-
-    ---
-
-    Bring lists of files or subjects found with CDA to the [ISB Cancer Gateway in the Cloud (ISB-CGC):octicons-link-external-16:](https://isb-cgc.org/){:target="_blank"} to instantly access both associated derived data and raw files, for use in cloud processing pipelines -- either in your own preferred environment or using ISB-CGC's free Google Cloud Platform credits program.
-    <a href="https://colab.research.google.com/github/CancerDataAggregator/Community-Notebooks/blob/main/Tutorials/010_isbcgc.ipynb" title="isbcgcusecase" class="md-button md-button">Test it out on Google Colab
-</a></p>
-
--   :simple-swagger:{ .lg .middle } __Developers__
-
-    ---
-
-    Are you building a metadata microservice? Connecting even more databases? Hosting a computational resource? <p>Whatever your use case, CDA can help.
-
-    [:octicons-arrow-right-24:**API documentation**](../documentation/developers/index.md)
-
--   :material-bell-alert-outline:{ .lg .middle } __What's new?__
-
-    ---
-
-    Recently Updated Pages:
-
-    - [Data Release](../release_notes/data_updates.md)
-    - [Code Release](../release_notes/cdapython.md)
-
--   :simple-mysql:{ .lg .middle } __Need even more data?__
-
-    ---
-
-    Do you dream of having a CDA database instance of your very own? Or CDA but bigger somehow?
-    We can make those dreams come true. Let's chat!
-
-    :material-email: cancerdataaggregator `@` gmail
-
-
-
+👉 **[Start exploring data](interactive.html)**  
+Try interactive search or view the API docs.
+<div style="margin-top: 1em; margin-bottom: 2em;">
+  <a href="interactive.html"><strong>👉 Start exploring data</strong></a><br>
+  <a href="interactive.html">Try interactive search</a> ·
+  <a href="api.html">View API docs</a>
 </div>
+```
 
+---
+
+## 🔎 Find what you need—your way
+
+### 🔍 Explore (No coding)
+Search and filter cancer datasets in a visual interface  
+👉 [Open interactive search](interactive.html)
+
+---
+
+### 📓 Analyze (Low code)
+Run queries and explore results in a ready-to-use notebook  
+👉 [Launch notebook in the cloud](notebooks.html)
+
+---
+
+### ⚙️ Build (API)
+Integrate CDA into pipelines and applications  
+👉 [View API documentation](api.html)
+
+---
+
+## 🖥️ See it in action
+
+Search across datasets with one query:
+
+- Filter by disease type, demographics, or study  
+- View harmonized results across repositories  
+- Export data for downstream analysis  
+
+👉 **Try a sample search:**  
+[Find adenocarcinoma subjects across datasets](interactive.html)
+
+---
+
+## 💡 Why use CDA?
+
+CDA removes the hardest parts of finding cancer data:
+
+- 🔗 **Search multiple data commons at once**  
+  No need to query each repository separately  
+
+- 🧠 **Harmonized data model**  
+  Use consistent terms across datasets  
+
+- ⚡ **From exploration to analysis quickly**  
+  Move from search → notebook → pipeline  
+
+- 🧪 **Flexible for all users**  
+  Works for researchers, analysts, and developers  
+
+---
+
+## 🧭 What you can find
+
+Use CDA to discover:
+
+- Subjects across studies  
+- Clinical and genomic data files  
+- Metadata across CRDC repositories  
+- Cohorts matching specific criteria  
+
+---
+
+## 🚀 Start in 10 seconds
+
+Not sure where to begin?
+
+👉 [Open interactive search with a pre-built example](interactive.html)  
+Explore adenocarcinoma datasets across repositories.
+
+---
+
+## 📚 Learn more
+
+- [About CDA](about_us.html)  
+- [Data model](data_model.html)  
+- [Tutorials](tutorials.html)  
+- [API reference](api.html)
+
+---
+
+## 🔬 Developed by
+
+The National Cancer Institute’s Cancer Research Data Commons (CRDC)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,79 +1,100 @@
 ---
 title:  Re-Search made simple
 ---
+# Search cancer data across multiple NCI data commons—instantly
 
-<div class="center" markdown> <p>With CDA you search by harmonized, common language terms. Using simple language you can get information about the subjects, files, or specimens that you care about in a standard dataframe format (tsv) that you can open in Excel, integrate into a pipeline or upload to your favorite cloud resource.</p></div>
+Cancer data is distributed across multiple systems—CDA brings it together.
 
+Find subjects, files, and studies using harmonized terms across repositories. No coding required.
 
-<div class="grid cards" markdown>
-
--   :material-clock-fast:{ .lg .middle } __Don't code? No problem!__
-
-    ---
-
-    Browse through a curated dataset of all subjects that have data at multiple data centers using an intuitive filtering tool right in this website. 
-<a href="interactive/" title="interactive search" class="md-button md-button">Head to our interactive page to try it out.
-</a></p>
-
--   :material-clock-fast:{ .lg .middle } __Low code, no install__
-
-    ---
-
-    Fill in the blanks in our pre-built queries to find the data you need without installing a thing. <p>Send your results to [Broad Institute FireCloud:octicons-link-external-16:](https://datacommons.cancer.gov/analytical-resource/broad-institute-firecloud){:target="_blank"} or [Velsera Cancer Genomics Cloud:octicons-link-external-16:](https://www.cancergenomicscloud.org/){:target="_blank"} for a complete cloud experience. Find the data you need, fetch all the files, and run your favorite bioinformatics pipeline *all without ever leaving your web browser.*<p>
-<a href="https://colab.research.google.com/github/CancerDataAggregator/Community-Notebooks/blob/main/Tutorials/Welcome.ipynb" title="Try it now" class="md-button md-button">Launch CDA in the cloud
-</a></p>
-
--   :fontawesome-brands-python:{ .lg .middle } __Power users__
-
-    ---
-
-    Install `cdapython` with `pip` and get up
-    and running in no time
-
-    ```bash
-    pip3 uninstall -y cdapython; pip3 install git+https://github.com/CancerDataAggregator/cdapython.git@develop
-    python3
-    ```
-
-    ```python
-    from cdapython import *
-    ```
-
--   :fontawesome-brands-python:{ .lg .middle } __Code in the Cloud__
-
-    ---
-
-    Bring lists of files or subjects found with CDA to the [ISB Cancer Gateway in the Cloud (ISB-CGC):octicons-link-external-16:](https://isb-cgc.org/){:target="_blank"} to instantly access both associated derived data and raw files, for use in cloud processing pipelines -- either in your own preferred environment or using ISB-CGC's free Google Cloud Platform credits program.
-    <a href="https://colab.research.google.com/github/CancerDataAggregator/Community-Notebooks/blob/main/Tutorials/010_isbcgc.ipynb" title="isbcgcusecase" class="md-button md-button">Test it out on Google Colab
-</a></p>
-
--   :simple-swagger:{ .lg .middle } __Developers__
-
-    ---
-
-    Are you building a metadata microservice? Connecting even more databases? Hosting a computational resource? <p>Whatever your use case, CDA can help.
-
-    [:octicons-arrow-right-24:**API documentation**](documentation/developers/)
-
--   :material-bell-alert-outline:{ .lg .middle } __What's new?__
-
-    ---
-
-    Recently Updated Pages:
-
-    - [Data Release](release_notes/data_updates.md)
-    - [Code Release](release_notes/cdapython.md)
-
--   :simple-mysql:{ .lg .middle } __Need even more data?__
-
-    ---
-
-    Do you dream of having a CDA database instance of your very own? Or CDA but bigger somehow?
-    We can make those dreams come true. Let's chat!
-
-    :material-email: cancerdataaggregator `@` gmail
-
-
-
+<div style="margin-top: 1em; margin-bottom: 2em;">
+  <a href="interactive.html"><strong>👉 Start exploring data</strong></a><br>
+  <a href="interactive.html">Try interactive search</a> ·
+  <a href="api.html">View API docs</a>
 </div>
 
+---
+
+## 🔎 Find what you need—your way
+
+### 🔍 Explore (No coding)
+Search and filter cancer datasets in a visual interface  
+👉 [Open interactive search](interactive.html)
+
+---
+
+### 📓 Analyze (Low code)
+Run queries and explore results in a ready-to-use notebook  
+👉 [Launch notebook in the cloud](notebooks.html)
+
+---
+
+### ⚙️ Build (API)
+Integrate CDA into pipelines and applications  
+👉 [View API documentation](api.html)
+
+---
+
+## 🖥️ See it in action
+
+Search across datasets with one query:
+
+- Filter by disease type, demographics, or study  
+- View harmonized results across repositories  
+- Export data for downstream analysis  
+
+👉 **Try a sample search:**  
+[Find adenocarcinoma subjects across datasets](interactive.html)
+
+---
+
+## 💡 Why use CDA?
+
+CDA removes the hardest parts of finding cancer data:
+
+- 🔗 **Search multiple data commons at once**  
+  No need to query each repository separately  
+
+- 🧠 **Harmonized data model**  
+  Use consistent terms across datasets  
+
+- ⚡ **From exploration to analysis quickly**  
+  Move from search → notebook → pipeline  
+
+- 🧪 **Flexible for all users**  
+  Works for researchers, analysts, and developers  
+
+---
+
+## 🧭 What you can find
+
+Use CDA to discover:
+
+- Subjects across studies  
+- Clinical and genomic data files  
+- Metadata across CRDC repositories  
+- Cohorts matching specific criteria  
+
+---
+
+## 🚀 Start in 10 seconds
+
+Not sure where to begin?
+
+👉 [Open interactive search with a pre-built example](interactive.html)  
+Explore adenocarcinoma datasets across repositories.
+
+---
+
+## 📚 Learn more
+
+- [About CDA](about_us.html)  
+- [Data model](data_model.html)  
+- [Tutorials](tutorials.html)  
+- [API reference](api.html)
+
+---
+
+## 🔬 Developed by
+
+The National Cancer Institute’s Cancer Research Data Commons (CRDC)

--- a/docs/interactive/google.html
+++ b/docs/interactive/google.html
@@ -7,7 +7,7 @@
 async function searchCDA() {
   const query = document.getElementById("searchBox").value;
 
-  const response = await fetch("https://cda.datacommons.cancer.gov/api/v1/subjects", {
+  const response = await fetch("https://cda.datacommons.cancer.gov/summary/subject", {
     method: "POST",
     headers: {
       "Content-Type": "application/json"

--- a/docs/interactive/google.html
+++ b/docs/interactive/google.html
@@ -1,19 +1,24 @@
-<input
-  type="text"
-  id="cda-search"
-  placeholder="Search cancer data (e.g. adenocarcinoma)"
-  style="width: 100%; padding: 10px; font-size: 16px;"
-/>
+<input id="searchBox" placeholder="Search cancer data (e.g. lung cancer)" />
+<button onclick="searchCDA()">Search</button>
+
+<pre id="results"></pre>
 
 <script>
-document.getElementById("cda-search").addEventListener("keypress", function(e) {
-  if (e.key === "Enter") {
-    const query = e.target.value.trim();
+async function searchCDA() {
+  const query = document.getElementById("searchBox").value;
 
-    // VERY simple mapping (expand this later)
-    const url = `/en/latest/interactive.html?search=${encodeURIComponent(query)}`;
+  const response = await fetch("https://cda.datacommons.cancer.gov/api/v1/subjects", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      search_list: [query]
+    })
+  });
 
-    window.location.href = url;
-  }
-});
+  const data = await response.json();
+  document.getElementById("results").textContent =
+    JSON.stringify(data, null, 2);
+}
 </script>

--- a/docs/interactive/google.html
+++ b/docs/interactive/google.html
@@ -13,7 +13,7 @@ async function searchCDA() {
       "Content-Type": "application/json"
     },
     body: JSON.stringify({
-      search_list: [query]
+      SEARCH_LIST: [query]
     })
   });
 

--- a/docs/interactive/google.html
+++ b/docs/interactive/google.html
@@ -7,7 +7,7 @@
 async function searchCDA() {
   const query = document.getElementById("searchBox").value;
 
-  const response = await fetch("https://cda.datacommons.cancer.gov/summary/subject", {
+  const response = await fetch("https://cda-dev.datacommons.cancer.gov/summary/subject", {
     method: "POST",
     headers: {
       "Content-Type": "application/json"

--- a/docs/interactive/google.html
+++ b/docs/interactive/google.html
@@ -1,0 +1,19 @@
+<input
+  type="text"
+  id="cda-search"
+  placeholder="Search cancer data (e.g. adenocarcinoma)"
+  style="width: 100%; padding: 10px; font-size: 16px;"
+/>
+
+<script>
+document.getElementById("cda-search").addEventListener("keypress", function(e) {
+  if (e.key === "Enter") {
+    const query = e.target.value.trim();
+
+    // VERY simple mapping (expand this later)
+    const url = `/en/latest/interactive.html?search=${encodeURIComponent(query)}`;
+
+    window.location.href = url;
+  }
+});
+</script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,7 @@ plugins:
           remove_input_tags:
               - hide_code
       include_source: True
-      execute: True
+      execute: False
       allow_errors: False
       ignore: ["documentation/cdapython/vignettes/005_TCIA.ipynb"]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ extra_css:
 nav:
   - Getting Started:
     - getting_started/index.md
+    - google search: interactive/google.html
     - Interactive Search: interactive/index.ipynb
     - getting_started/no-install.md
     - getting_started/install.md


### PR DESCRIPTION
Everyone keeps telling me I need to try AI sincerely. So here we are. I asked chatGPT to assess the documentation homepage and tell me how it would improve it for low and no code users.

<html><head></head><body><p>I looked through your homepage, and the core issue isn’t that it’s <em>bad</em>—it’s that it reads like documentation when it needs to act like a <strong>landing page that converts confused visitors into confident users</strong>.</p><p>Right now, it’s informative, but it doesn’t <em>guide</em>. Below is a focused breakdown of what would make it significantly more effective.</p><hr><h1>🔍 What your homepage does well (keep this)</h1><ul><li><p>Clear statement of purpose: CDA helps search harmonized cancer data (<a href="https://cda.readthedocs.io/en/latest/?utm_source=chatgpt.com" title="Re-Search made simple - Cancer Data Aggregator">cda.readthedocs.io</a>)</p></li><li><p>Multiple entry points (no-code, low-code, API)</p></li><li><p>Strong technical depth for motivated users</p></li></ul><p>👉 The problem: <strong>this clarity is buried instead of surfaced.</strong></p><hr><h1>🚨 The biggest problems (and how to fix them)</h1><h2>1. Your hero section is too vague</h2><p>Current message:</p><blockquote><p>“Re-Search made simple”</p></blockquote><p>That’s catchy, but not <em>specific enough for first-time users</em>.</p><h3>Fix: Make the value concrete in 5 seconds</h3><p>Rewrite the top section to answer:</p><ul><li><p>What is this?</p></li><li><p>Who is it for?</p></li><li><p>What can I do right now?</p></li></ul><p><strong>Example rewrite:</strong></p><blockquote><p>Search cancer datasets across NCI data commons in one place<br>Find subjects, files, and studies using simple terms—no coding required.</p></blockquote><p>Then add <strong>one primary CTA</strong>:</p><ul><li><p>“Start searching data”</p></li><li><p>“Try interactive search”</p></li></ul><p>👉 Right now, users have to <em>figure out where to go</em>. That’s friction.</p><hr><h2>2. You’re mixing audiences without guiding them</h2><p>You currently have:</p><ul><li><p>“Don’t code?”</p></li><li><p>“Power users”</p></li><li><p>“Developers”</p></li></ul><p>That’s good—but it’s buried and not visually decisive.</p><h3>Fix: Turn this into a clear decision section</h3><p>Use a <strong>3-card layout immediately under the hero</strong>:</p>
I want to… | Action
-- | --
Explore data (no code) | Open interactive search
Run queries (low code) | Launch notebook
Build tools (API) | View API docs

<p>👉 This aligns with your real strengths: multiple access paths (<a href="https://cda.readthedocs.io/en/latest/?utm_source=chatgpt.com" title="Re-Search made simple - Cancer Data Aggregator">cda.readthedocs.io</a>)</p><hr><h2>3. No visual proof of what the tool actually does</h2><p>You describe:</p><ul><li><p>interactive search</p></li><li><p>harmonized data</p></li><li><p>filtering</p></li></ul><p>But you don’t <em>show it clearly up front</em>.</p><h3>Fix: Add a visual demo section</h3><p>Include:</p><ul><li><p>Screenshot or GIF of the interactive table</p></li><li><p>Example query → result</p></li></ul><p>Why this matters:</p><ul><li><p>Your tool is conceptually complex (“harmonized metadata across repositories” (<a href="https://cda.readthedocs.io/en/latest/about_us/?utm_source=chatgpt.com" title="About Us - Cancer Data Aggregator">cda.readthedocs.io</a>))</p></li><li><p>A visual instantly reduces cognitive load</p></li></ul><hr><h2>4. The “why CDA” value is buried</h2><p>Your strongest differentiator is:</p><ul><li><p>Cross-repository harmonization</p></li><li><p>Unified search across CRDC datasets (<a href="https://www.cancer.gov/about-nci/organization/cbiit/training/library/cda?utm_source=chatgpt.com" title="Using the Cancer Data Aggregator - NCI">Cancer.gov</a>)</p></li></ul><p>But that’s hidden in text blocks.</p><h3>Fix: Add a “Why CDA?” section</h3><p>Make this scannable:</p><p><strong>Why use CDA?</strong></p><ul><li><p>🔗 Search across multiple cancer data commons at once</p></li><li><p>🧠 Harmonized terms (no need to learn each dataset’s schema)</p></li><li><p>⚡ Export results directly to pipelines or cloud platforms</p></li><li><p>🧪 Works for no-code → advanced workflows</p></li></ul><p>👉 This is your competitive edge—highlight it early.</p><hr><h2>5. Weak call-to-action structure</h2><p>You have CTAs like:</p><ul><li><p>“Launch CDA in the cloud”</p></li><li><p>“Try it out”</p></li><li><p>“API documentation”</p></li></ul><p>But they’re scattered and not prioritized.</p><h3>Fix: Use a CTA hierarchy</h3><ul><li><p>Primary (top): <strong>Start searching</strong></p></li><li><p>Secondary: Try notebook / interactive page</p></li><li><p>Tertiary: API docs</p></li></ul><p>👉 A homepage should feel like a funnel, not a menu.</p><hr><h2>6. It feels like documentation, not a product</h2><p>The page is structured like:</p><ul><li><p>Feature descriptions</p></li><li><p>Technical notes</p></li><li><p>Links</p></li></ul><p>But users need:</p><ul><li><p>Orientation</p></li><li><p>Confidence</p></li><li><p>Momentum</p></li></ul><h3>Fix: Add a simple narrative flow</h3><p>Structure it like this:</p><ol><li><p><strong>Hero: What + why</strong></p></li><li><p><strong>Quick start (choose your path)</strong></p></li><li><p><strong>Visual demo</strong></p></li><li><p><strong>Key benefits</strong></p></li><li><p><strong>Deeper links (docs, API, etc.)</strong></p></li></ol><hr><h2>7. Missing “quick win” onboarding</h2><p>You <em>do</em> have an interactive search page, but it’s not framed as:</p><p>👉 “Try this in 10 seconds”</p><h3>Fix: Add a “Start here” example</h3><p>For example:</p><blockquote><p>Try this: Find all adenocarcinoma subjects across datasets<br>→ [Open pre-filled search]</p></blockquote><p>This leverages what you already built:</p><ul><li><p>default filtered example in interactive search (<a href="https://cda.readthedocs.io/en/latest/interactive/?utm_source=chatgpt.com" title="Interactive Search - Cancer Data Aggregator">cda.readthedocs.io</a>)</p></li></ul><hr><h1>🧠 Strategic insight (this matters most)</h1><p>Your tool solves a <strong>hard problem</strong>:</p><blockquote><p>finding and unifying cancer datasets across multiple systems</p></blockquote><p>But your homepage assumes users already understand:</p><ul><li><p>what harmonization means</p></li><li><p>why cross-dataset search is hard</p></li><li><p>why CDA is valuable</p></li></ul><p>👉 Most users don’t.</p><p>So your homepage needs to shift from:</p><blockquote><p>“Here’s what CDA does”</p></blockquote><p>to:</p><blockquote><p>“Here’s the problem you have—and how CDA instantly solves it”</p></blockquote><hr><h1>✨ If you only change 3 things</h1><ol><li><p>Replace the hero with a <strong>clear, specific value proposition</strong></p></li><li><p>Add a <strong>3-path “choose your workflow” section</strong></p></li><li><p>Show a <strong>visual example of the tool in action</strong></p></li></ol><p>That alone would dramatically improve usability and adoption.</p><hr><p>If you want, I can rewrite your homepage top-to-bottom (copy + layout) tailored specifically for researchers vs. data scientists—that would get you much closer to a “this is obviously useful” experience within seconds.</p></body></html>I looked through your homepage, and the core issue isn’t that it’s *bad*—it’s that it reads like documentation when it needs to act like a **landing page that converts confused visitors into confident users**.

Right now, it’s informative, but it doesn’t *guide*. Below is a focused breakdown of what would make it significantly more effective.

---

# 🔍 What your homepage does well (keep this)

* Clear statement of purpose: CDA helps search harmonized cancer data ([[cda.readthedocs.io](https://cda.readthedocs.io/en/latest/?utm_source=chatgpt.com)][1])
* Multiple entry points (no-code, low-code, API)
* Strong technical depth for motivated users

👉 The problem: **this clarity is buried instead of surfaced.**

---

# 🚨 The biggest problems (and how to fix them)

## 1. Your hero section is too vague

Current message:

> “Re-Search made simple”

That’s catchy, but not *specific enough for first-time users*.

### Fix: Make the value concrete in 5 seconds

Rewrite the top section to answer:

* What is this?
* Who is it for?
* What can I do right now?

**Example rewrite:**

> Search cancer datasets across NCI data commons in one place
> Find subjects, files, and studies using simple terms—no coding required.

Then add **one primary CTA**:

* “Start searching data”
* “Try interactive search”

👉 Right now, users have to *figure out where to go*. That’s friction.

---

## 2. You’re mixing audiences without guiding them

You currently have:

* “Don’t code?”
* “Power users”
* “Developers”

That’s good—but it’s buried and not visually decisive.

### Fix: Turn this into a clear decision section

Use a **3-card layout immediately under the hero**:

| I want to…             | Action                  |
| ---------------------- | ----------------------- |
| Explore data (no code) | Open interactive search |
| Run queries (low code) | Launch notebook         |
| Build tools (API)      | View API docs           |

👉 This aligns with your real strengths: multiple access paths ([[cda.readthedocs.io](https://cda.readthedocs.io/en/latest/?utm_source=chatgpt.com)][1])

---

## 3. No visual proof of what the tool actually does

You describe:

* interactive search
* harmonized data
* filtering

But you don’t *show it clearly up front*.

### Fix: Add a visual demo section

Include:

* Screenshot or GIF of the interactive table
* Example query → result

Why this matters:

* Your tool is conceptually complex (“harmonized metadata across repositories” ([[cda.readthedocs.io](https://cda.readthedocs.io/en/latest/about_us/?utm_source=chatgpt.com)][2]))
* A visual instantly reduces cognitive load

---

## 4. The “why CDA” value is buried

Your strongest differentiator is:

* Cross-repository harmonization
* Unified search across CRDC datasets ([[Cancer.gov](https://www.cancer.gov/about-nci/organization/cbiit/training/library/cda?utm_source=chatgpt.com)][3])

But that’s hidden in text blocks.

### Fix: Add a “Why CDA?” section

Make this scannable:

**Why use CDA?**

* 🔗 Search across multiple cancer data commons at once
* 🧠 Harmonized terms (no need to learn each dataset’s schema)
* ⚡ Export results directly to pipelines or cloud platforms
* 🧪 Works for no-code → advanced workflows

👉 This is your competitive edge—highlight it early.

---

## 5. Weak call-to-action structure

You have CTAs like:

* “Launch CDA in the cloud”
* “Try it out”
* “API documentation”

But they’re scattered and not prioritized.

### Fix: Use a CTA hierarchy

* Primary (top): **Start searching**
* Secondary: Try notebook / interactive page
* Tertiary: API docs

👉 A homepage should feel like a funnel, not a menu.

---

## 6. It feels like documentation, not a product

The page is structured like:

* Feature descriptions
* Technical notes
* Links

But users need:

* Orientation
* Confidence
* Momentum

### Fix: Add a simple narrative flow

Structure it like this:

1. **Hero: What + why**
2. **Quick start (choose your path)**
3. **Visual demo**
4. **Key benefits**
5. **Deeper links (docs, API, etc.)**

---

## 7. Missing “quick win” onboarding

You *do* have an interactive search page, but it’s not framed as:

👉 “Try this in 10 seconds”

### Fix: Add a “Start here” example

For example:

> Try this: Find all adenocarcinoma subjects across datasets
> → [Open pre-filled search]

This leverages what you already built:

* default filtered example in interactive search ([[cda.readthedocs.io](https://cda.readthedocs.io/en/latest/interactive/?utm_source=chatgpt.com)][4])

---

# 🧠 Strategic insight (this matters most)

Your tool solves a **hard problem**:

> finding and unifying cancer datasets across multiple systems

But your homepage assumes users already understand:

* what harmonization means
* why cross-dataset search is hard
* why CDA is valuable

👉 Most users don’t.

So your homepage needs to shift from:

> “Here’s what CDA does”

to:

> “Here’s the problem you have—and how CDA instantly solves it”

---

# ✨ If you only change 3 things

1. Replace the hero with a **clear, specific value proposition**
2. Add a **3-path “choose your workflow” section**
3. Show a **visual example of the tool in action**

That alone would dramatically improve usability and adoption.

---

If you want, I can rewrite your homepage top-to-bottom (copy + layout) tailored specifically for researchers vs. data scientists—that would get you much closer to a “this is obviously useful” experience within seconds.

[1]: https://cda.readthedocs.io/en/latest/?utm_source=chatgpt.com "Re-Search made simple - Cancer Data Aggregator"
[2]: https://cda.readthedocs.io/en/latest/about_us/?utm_source=chatgpt.com "About Us - Cancer Data Aggregator"
[3]: https://www.cancer.gov/about-nci/organization/cbiit/training/library/cda?utm_source=chatgpt.com "Using the Cancer Data Aggregator - NCI"
[4]: https://cda.readthedocs.io/en/latest/interactive/?utm_source=chatgpt.com "Interactive Search - Cancer Data Aggregator"